### PR TITLE
PHP warnings on Case Dashboard and Find Cases

### DIFF
--- a/CRM/Case/Form/Search.php
+++ b/CRM/Case/Form/Search.php
@@ -301,7 +301,7 @@ class CRM_Case_Form_Search extends CRM_Core_Form_Search {
    *
    * @return array|bool
    */
-  public static function formRule($fields) {
+  public static function formRule($fields, $files, $form) {
     $errors = [];
 
     if (!empty($errors)) {


### PR DESCRIPTION
Overview
----------------------------------------
[Remove reference to other PR in this screwed up PR since it shows up on the actual PR] adds a formRule function to CRM_Core_Form_Search which is the parent of CRM_Case_Form_Search. It already has a formRule function but the signatures don't match.

Before
----------------------------------------
Warning: Declaration of CRM_Case_Form_Search::formRule($fields) should be compatible with CRM_Core_Form_Search::formRule($fields, $files, $form) in require_once() (line 37 of sites\all\modules\civicrm\CRM\Case\Form\Search.php).

After
----------------------------------------
All good.
